### PR TITLE
Migrate notebook links from bitbucket to github

### DIFF
--- a/notebooks/2015 LCA Seminar - Class 4 - Hybrid LCA.ipynb
+++ b/notebooks/2015 LCA Seminar - Class 4 - Hybrid LCA.ipynb
@@ -149,7 +149,7 @@
     "\n",
     "In other words, the technosphere matrix is very dense. Ecoinvent is stored as a [sparse matrix](http://docs.scipy.org/doc/scipy/reference/sparse.html), where data is only provided in about 1.5% of all possible locations - every other value is zero, and these zeros are not stored, only implied. However, the IO table has a fill rate of about 50%, meaning that we store every value in the matrix. The technosphere in ecoinvent 2.2 is about 4000 by 4000, but we only need to store about 40.000 numbers. The technosphere matrix is exiobase is about 8000 by 8000, but we store around 35.000.000 numbers.\n",
     "\n",
-    "We use a special backend for IO databases, as our standard storage mechanisms simply fall apart with such large data sets. You can see this [backend here](https://bitbucket.org/cmutel/brightway2-data/src/tip/bw2data/backends/iotable/__init__.py?at=2.0&fileviewer=file-view-default)."
+    "We use a special backend for IO databases, as our standard storage mechanisms simply fall apart with such large data sets. You can see this [backend here](https://github.com/brightway-lca/brightway2-data/blob/master/bw2data/backends/iotable/__init__.py)."
    ]
   },
   {
@@ -363,7 +363,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "However, we have a special LCA class that only does [dense technosphere matrices](https://bitbucket.org/cmutel/brightway2-calc/src/tip/bw2calc/dense_lca.py?at=default&fileviewer=file-view-default). If we use it, we will get better performance, because the linear solver assumes dense instead of sparse matrices:"
+    "However, we have a special LCA class that only does [dense technosphere matrices](https://github.com/brightway-lca/brightway2-calc/blob/master/bw2calc/dense_lca.py). If we use it, we will get better performance, because the linear solver assumes dense instead of sparse matrices:"
    ]
   },
   {

--- a/notebooks/Defining a new Matrix - example of Weighting and Normalization.ipynb
+++ b/notebooks/Defining a new Matrix - example of Weighting and Normalization.ipynb
@@ -112,7 +112,7 @@
     "\n",
     "First, we specify the `metadata`: this tells us *where* to register each instance of `Weighting`. We defined the `weightings` metadata store above.\n",
     "\n",
-    "Next, we specify what additional fields need to be added to our [processed array](http://brightway2.readthedocs.org/en/latest/key-concepts/processed.html). Usually we would have somehting like a biosphere flow, which would then get mapped to rows in the biosphere matrix. But as weightings are a single number, we don't need to know where they go - this will be a static value, not a matrix at all. Aside from our uncertainty dictionary, we don't need anything else, and the values for the uncertainty field are [added automatically](https://bitbucket.org/cmutel/brightway2-data/src/a6b58d9e440851db0cada2d804976e9793ddb3f0/bw2data/data_store.py?at=default#cl-98).\n",
+    "Next, we specify what additional fields need to be added to our [processed array](http://brightway2.readthedocs.org/en/latest/key-concepts/processed.html). Usually we would have somehting like a biosphere flow, which would then get mapped to rows in the biosphere matrix. But as weightings are a single number, we don't need to know where they go - this will be a static value, not a matrix at all. Aside from our uncertainty dictionary, we don't need anything else, and the values for the uncertainty field are [added automatically](https://github.com/brightway-lca/brightway2-data/blob/13c2dfa67814e2d7b95fb24eb80bdc9c22541051/bw2data/data_store.py#L185).\n",
     "\n",
     "Similary, the definition of `.process_data(row)` doesn't seem to do anything, because in this case we don't need to do anything. We will have a more complicated `process_data` method below when defining normalization."
    ]


### PR DESCRIPTION
Done:
- scanned notebooks until `IO - Importing Agribalyse 1.3 with Ecoinvent 3.2 cutoff.ipynb`
- migrated 2015 LCA Seminar - Class 4 - Hybrid LCA.ipynb
- migrated Defining a new Matrix - example of Weighting and Normalization.ipynb

Open problems:
- [Defining a new Matrix - example of Weighting and Normalization.ipynb](https://github.com/brightway-lca/brightway2/blob/bitbucket-migration/notebooks/Defining%20a%20new%20Matrix%20-%20example%20of%20Weighting%20and%20Normalization.ipynb) contains multiple links to https://bw2data.readthedocs.org/ which is not available anymore
- [Getting Started with Brightway2.ipynb](https://github.com/brightway-lca/brightway2/blame/bitbucket-migration/notebooks/Getting%20Started%20with%20Brightway2.ipynb#L370) contains a link to Whoosh on bitbucket, which is not available anymore
- [IO - Importing Agribalyse 1.3 with Ecoinvent 3.2 cutoff.ipynb](https://github.com/brightway-lca/brightway2/blame/bitbucket-migration/notebooks/IO%20-%20Importing%20Agribalyse%201.3%20with%20Ecoinvent%203.2%20cutoff.ipynb#L298) contains multiple hard links to commits on bitbucket, which I cannot resolve anymore