### PR TITLE
Bump `bw2io` to `0.8.10`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ packages = [
     "bw2analyzer<0.10.99",
     "bw2calc==1.8.2",
     "bw2data==3.6.6",
-    "bw2io<0.8.9",
+    "bw2io==0.8.10",
     "bw2parameters>=0.6.5",
     "docopt",
     "eight",

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ packages = [
 
 setup(
     name='brightway2',
-    version="2.4.3",
+    version="2.4.4",
     packages=["brightway2"],
     author="Chris Mutel",
     author_email="cmutel@gmail.com",


### PR DESCRIPTION
...getting ready for a PyPI and conda-forge release. As requested by the Activity Browser MVP @marc-vdm.